### PR TITLE
Add support for LLP – Lower Layer Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,18 @@ msg.pid[3] = "123456"
 msg.to_hl7
 => "MSH|^~\\&|\r\nPID|||123456"
 ```
+### Transmitting via TCP/IP
+
+The Lower Layer Protocol (LLP) is the most common mechanism for sending unencrypted HL7 via TCP/IP over a local area network. In order to be complaint with this protocol you can use `to_llp` method which wraps the HL7 message with the appropriate header and trailer.
+
+```ruby
+msg = SimpleHL7::Message.new
+msg.msh[12] = '2.5'
+
+socket = TCPSocket.open(ipaddr, port)
+socket.write msg.to_llp
+socket.close
+```
 
 ### Parsing
 

--- a/lib/simple_hl7/message.rb
+++ b/lib/simple_hl7/message.rb
@@ -34,6 +34,14 @@ module SimpleHL7
       @segments.map {|s| s.to_hl7(separator_chars)}.join(@segment_separator)
     end
 
+    # Generate a LLP string from this message
+    # Commonly used for transmitting HL7 messages via TCP/IP
+    #
+    # @return [String] The generated LLP string
+    def to_llp
+      "\x0b#{to_hl7}\x1c\r"
+    end
+
     # Get an array representation of the HL7 message. This can be useful
     # to help debug problems.
     #

--- a/spec/simple_hl7/message_spec.rb
+++ b/spec/simple_hl7/message_spec.rb
@@ -29,6 +29,24 @@ module SimpleHL7
       end
     end
 
+    describe "#to_llp" do
+      it "generates an llp message" do
+        msg = Message.new
+        msg.msh[6] = "accountid"
+        msg.pid[5] = "User"
+        msg.pid[5][2] = "Test"
+        msg.to_llp.should == "\x0bMSH|^~\\&||||accountid\rPID|||||User^Test\x1c\r"
+      end
+
+      it "generates a llp message with a non-default segment separator" do
+        msg = Message.new(segment_separator: "\r\n")
+        msg.msh[6] = "accountid"
+        msg.pid[5] = "User"
+        msg.pid[5][2] = "Test"
+        msg.to_llp.should == "\x0bMSH|^~\\&||||accountid\r\nPID|||||User^Test\x1c\r"
+      end
+    end
+
     describe "#add_segment" do
       it "adds segments properly" do
         msg = Message.new


### PR DESCRIPTION
Thanks for this gem, guys!

Btw, I had some issues while sending HL7 messages via TCP/IP and manage to solve them by adding LLP support to `simple_hl7` gem.

```
The Lower Layer Protocol (LLP), sometimes referred to as the Minimal Lower Layer Protocol (MLLP),
is the absolute standard for transmitting HL7 messages via TCP/IP. Since TCP/IP is a continuous
stream of bytes, a wrapping protocol is required for communications code to be able to recognize the
start and the end of each message.

When using LLP, an HL7 message must be wrapped using a header and trailer (also called a footer) 
to signify the beginning and end of a message.
```

Ref: http://www.interfaceware.com/blog/common-hl7-transports/
cc: @hportlock