### PR TITLE
Allow to parse LLP messages received over TCP/IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,17 @@ hl7_str = "MSH|^~\\&|||||||ADT^A04|12345678|D|2.5\r\nPID|||454545||Doe^John"
 msg = SimpleHL7::Message.parse(hl7_str, segment_separator: "\r\n")
 ```
 
+### Parsing LLP messages
+
+In case you are parsing HL7 messages received over TCP/IP using the LLP protocol, use the `parse_llp` method
+
+```ruby
+llp_str = "\x0bMSH|^~\\&|||||||ADT^A04|12345678|D|2.5\rPID|||454545||Doe^John\x1c\r"
+msg = SimpleHL7::Message.parse_llp(llp_str)
+```
+
+Once the message is parsed you can follow the same methods pointed above to pull out values
+
 ## Contributing
 
 1. Fork it

--- a/lib/simple_hl7/message.rb
+++ b/lib/simple_hl7/message.rb
@@ -130,7 +130,11 @@ module SimpleHL7
     #     generating HL7, defaults to "\r".
     # @return [Message] The parsed HL7 Message
     def self.parse_llp(str, options = nil)
-      parse(str, options)
+      if llp = str.match(/\x0b(.*)\x1c\r/)
+        parse(llp.captures.first, options)
+      else
+        raise ArgumentError, "Invalid LLP message, header and trailer were expected."
+      end
     end
   end
 end

--- a/lib/simple_hl7/message.rb
+++ b/lib/simple_hl7/message.rb
@@ -120,5 +120,17 @@ module SimpleHL7
       end
       msg
     end
+
+    # Parses a HL7 LLP (Lower Layer Protocol) string into a Message
+    #
+    # @param str [String] The llp string to parse.
+    # @param options [Hash] Options for parsing, keys are symbols, accepted
+    #   values:
+    #   segment_separator [String] The string to place between segments when
+    #     generating HL7, defaults to "\r".
+    # @return [Message] The parsed HL7 Message
+    def self.parse_llp(str, options = nil)
+      parse(str, options)
+    end
   end
 end

--- a/spec/simple_hl7/message_spec.rb
+++ b/spec/simple_hl7/message_spec.rb
@@ -85,6 +85,12 @@ module SimpleHL7
         msg.pid[5][2].to_s.should == "Test"
         msg.pid[5].r(2)[1].to_s.should == "Repeat"
       end
+
+      it "raise an error on NON llp messages" do
+        expect {
+          Message.parse_llp("MSH|^~\\&||||accountid\rPID|||||User^Test~Repeat")
+        }.to raise_error(ArgumentError, /Invalid LLP message/)
+      end
     end
   end
 end

--- a/spec/simple_hl7/message_spec.rb
+++ b/spec/simple_hl7/message_spec.rb
@@ -76,5 +76,15 @@ module SimpleHL7
         msg.pid[5][2].to_s.should == "Test"
       end
     end
+
+    describe "#parse_llp" do
+      it "properly parses a llp string" do
+        msg = Message.parse_llp("\x0bMSH|^~\\&||||accountid\rPID|||||User^Test~Repeat\x1c\r")
+        msg.msh[6].to_s.should == "accountid"
+        msg.pid[5].to_s.should == "User"
+        msg.pid[5][2].to_s.should == "Test"
+        msg.pid[5].r(2)[1].to_s.should == "Repeat"
+      end
+    end
   end
 end


### PR DESCRIPTION
The current `parse` implementation do not take LLP messages into account, it only works with HL7 strings

This PR add the `parse_llp` method so we can process hl7 messages received over tcp/ip using the LLP protocol, in summary:

- Added a failing spec on https://github.com/alivecor/simple_hl7/commit/5d84b6313140b6bb14c8ce8d714ed938ff8d10aa
- Make the test pass on https://github.com/alivecor/simple_hl7/commit/1cd3524450278074eef042d081550d271a04e372
- Added some documentation to the README