### PR TITLE
Make initial value optional

### DIFF
--- a/lib/simple_hl7/subcomponent.rb
+++ b/lib/simple_hl7/subcomponent.rb
@@ -2,7 +2,7 @@ module SimpleHL7
   class Subcomponent
     attr_accessor :value
 
-    def initialize(value)
+    def initialize(value = nil)
       @value = value.nil? ? '' : value
     end
 


### PR DESCRIPTION
Receiving the following error:

```
ArgumentError:
        wrong number of arguments (given 0, expected 1)
      # ./bundle/ruby/2.3.0/gems/simple_hl7-1.0.0/lib/simple_hl7/subcomponent.rb:5:in `initialize'
      # ./bundle/ruby/2.3.0/gems/simple_hl7-1.0.0/lib/simple_hl7/composite.rb:42:in `new'
      # ./bundle/ruby/2.3.0/gems/simple_hl7-1.0.0/lib/simple_hl7/composite.rb:42:in `get_subcomposite'
```

Looks like Subcomponent doesn't intialize correctly from `composite.rb:42`